### PR TITLE
Frevert/feature/add fmt

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,11 +34,11 @@ jobs:
           rustup update stable
           rustup target add wasm32-unknown-unknown --toolchain nightly
 
-      # Check formatting of node and runtime according to .rustfmt.toml rules
+      # Check formatting of project according to .rustfmt.toml rules
       - name: Lint Code
         run: |
           rustfmt \
-          node/src/lib.rs
+          node/src/lib.rs \
           pallets/nft/src/lib.rs \
           pallets/kitties/src/lib.rs \
           runtime/src/lib.rs --check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,11 +37,7 @@ jobs:
       # Check formatting of project according to .rustfmt.toml rules
       - name: Lint Code
         run: |
-          rustfmt \
-          node/src/lib.rs \
-          pallets/nft/src/lib.rs \
-          pallets/kitties/src/lib.rs \
-          runtime/src/lib.rs --check
+          cargo fmt -- --check
 
       - name: Check Build
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,11 +34,14 @@ jobs:
           rustup update stable
           rustup target add wasm32-unknown-unknown --toolchain nightly
 
+      # Check formatting of node and runtime according to .rustfmt.toml rules
       - name: Lint Code
         run: |
-          rustfmt pallets/nft/src/lib.rs  --check
-          rustfmt pallets/kitties/src/lib.rs  --check
-          rustfmt runtime/src/lib.rs --check
+          rustfmt \
+          node/src/lib.rs
+          pallets/nft/src/lib.rs \
+          pallets/kitties/src/lib.rs \
+          runtime/src/lib.rs --check
 
       - name: Check Build
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,6 +34,12 @@ jobs:
           rustup update stable
           rustup target add wasm32-unknown-unknown --toolchain nightly
 
+      - name: Lint Code
+        run: |
+          rustfmt pallets/nft/src/lib.rs  --check
+          rustfmt pallets/kitties/src/lib.rs  --check
+          rustfmt runtime/src/lib.rs --check
+
       - name: Check Build
         run: |
           SKIP_WASM_BUILD=1 cargo check --release

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ The provided `cargo run` command will launch a temporary node and its state will
 you terminate the process. After the project has been built, there are other ways to launch the
 node.
 
+## Format code style
+
+The project relies on [rustfmt](https://github.com/rust-lang/rustfmt) for automatic code formatting. To keep the formatting in the project consistent for changes, run `cargo fmt` before making commits.
+
 ### Single-Node Development Chain
 
 This command will start the single-node development chain with persistent state:

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,13 +1,13 @@
-use sp_core::{Pair, Public, sr25519};
 use anmol_runtime::{
-	AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig,
-	SudoConfig, SystemConfig, WASM_BINARY, Signature
+	AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, Signature, SudoConfig,
+	SystemConfig, WASM_BINARY,
 };
-use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_finality_grandpa::AuthorityId as GrandpaId;
-use sp_runtime::traits::{Verify, IdentifyAccount};
-use sc_service::{ChainType, Properties};
 use hex_literal::hex;
+use sc_service::{ChainType, Properties};
+use sp_consensus_aura::sr25519::AuthorityId as AuraId;
+use sp_core::{sr25519, Pair, Public};
+use sp_finality_grandpa::AuthorityId as GrandpaId;
+use sp_runtime::traits::{IdentifyAccount, Verify};
 
 // The URL for the telemetry server.
 // const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
@@ -25,18 +25,16 @@ pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Pu
 type AccountPublic = <Signature as Verify>::Signer;
 
 /// Generate an account ID from seed.
-pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId where
-	AccountPublic: From<<TPublic::Pair as Pair>::Public>
+pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
+where
+	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
 {
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }
 
 /// Generate an Aura authority key.
 pub fn authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId) {
-	(
-		get_from_seed::<AuraId>(s),
-		get_from_seed::<GrandpaId>(s),
-	)
+	(get_from_seed::<AuraId>(s), get_from_seed::<GrandpaId>(s))
 }
 
 pub fn chain_properties() -> Properties {
@@ -56,26 +54,25 @@ pub fn development_config() -> Result<ChainSpec, String> {
 		// ID
 		"dev",
 		ChainType::Development,
-		move || testnet_genesis(
-			wasm_binary,
-			// Initial PoA authorities
-			vec![
-				authority_keys_from_seed("Alice"),
-			],
-			// Sudo account
-			get_account_id_from_seed::<sr25519::Public>("Alice"),
-			// Pre-funded accounts
-			vec![
+		move || {
+			testnet_genesis(
+				wasm_binary,
+				// Initial PoA authorities
+				vec![authority_keys_from_seed("Alice")],
+				// Sudo account
 				get_account_id_from_seed::<sr25519::Public>("Alice"),
-				get_account_id_from_seed::<sr25519::Public>("Bob"),
-				get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-				get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-				
-				// Offchain worker keystore account
-				hex!("ae70ee67f0b51dacc666f0d17f46fbead307846682385f69bb1c9d5d77701616").into(),
-			],
-			true,
-		),
+				// Pre-funded accounts
+				vec![
+					get_account_id_from_seed::<sr25519::Public>("Alice"),
+					get_account_id_from_seed::<sr25519::Public>("Bob"),
+					get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
+					get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+					// Offchain worker keystore account
+					hex!("ae70ee67f0b51dacc666f0d17f46fbead307846682385f69bb1c9d5d77701616").into(),
+				],
+				true,
+			)
+		},
 		// Bootnodes
 		vec![],
 		// Telemetry
@@ -98,32 +95,34 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 		// ID
 		"local_testnet",
 		ChainType::Local,
-		move || testnet_genesis(
-			wasm_binary,
-			// Initial PoA authorities
-			vec![
-				authority_keys_from_seed("Alice"),
-				authority_keys_from_seed("Bob"),
-			],
-			// Sudo account
-			get_account_id_from_seed::<sr25519::Public>("Alice"),
-			// Pre-funded accounts
-			vec![
+		move || {
+			testnet_genesis(
+				wasm_binary,
+				// Initial PoA authorities
+				vec![
+					authority_keys_from_seed("Alice"),
+					authority_keys_from_seed("Bob"),
+				],
+				// Sudo account
 				get_account_id_from_seed::<sr25519::Public>("Alice"),
-				get_account_id_from_seed::<sr25519::Public>("Bob"),
-				get_account_id_from_seed::<sr25519::Public>("Charlie"),
-				get_account_id_from_seed::<sr25519::Public>("Dave"),
-				get_account_id_from_seed::<sr25519::Public>("Eve"),
-				get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-				get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-				get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-				get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-				get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-				get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-				get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
-			],
-			true,
-		),
+				// Pre-funded accounts
+				vec![
+					get_account_id_from_seed::<sr25519::Public>("Alice"),
+					get_account_id_from_seed::<sr25519::Public>("Bob"),
+					get_account_id_from_seed::<sr25519::Public>("Charlie"),
+					get_account_id_from_seed::<sr25519::Public>("Dave"),
+					get_account_id_from_seed::<sr25519::Public>("Eve"),
+					get_account_id_from_seed::<sr25519::Public>("Ferdie"),
+					get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
+					get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+					get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
+					get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
+					get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
+					get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+				],
+				true,
+			)
+		},
 		// Bootnodes
 		vec![],
 		// Telemetry
@@ -153,13 +152,20 @@ fn testnet_genesis(
 		}),
 		pallet_balances: Some(BalancesConfig {
 			// Configure endowed accounts with initial balance of 1 << 60.
-			balances: endowed_accounts.iter().cloned().map(|k|(k, 1 << 60)).collect(),
+			balances: endowed_accounts
+				.iter()
+				.cloned()
+				.map(|k| (k, 1 << 60))
+				.collect(),
 		}),
 		pallet_aura: Some(AuraConfig {
 			authorities: initial_authorities.iter().map(|x| (x.0.clone())).collect(),
 		}),
 		pallet_grandpa: Some(GrandpaConfig {
-			authorities: initial_authorities.iter().map(|x| (x.1.clone(), 1)).collect(),
+			authorities: initial_authorities
+				.iter()
+				.map(|x| (x.1.clone(), 1))
+				.collect(),
 		}),
 		pallet_sudo: Some(SudoConfig {
 			// Assign network admin rights.

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,5 +1,5 @@
-use structopt::StructOpt;
 use sc_cli::RunCmd;
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub struct Cli {

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -15,11 +15,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{chain_spec, service};
 use crate::cli::{Cli, Subcommand};
-use sc_cli::{SubstrateCli, RuntimeVersion, Role, ChainSpec};
-use sc_service::PartialComponents;
+use crate::{chain_spec, service};
 use anmol_runtime::Block;
+use sc_cli::{ChainSpec, Role, RuntimeVersion, SubstrateCli};
+use sc_service::PartialComponents;
 
 impl SubstrateCli for Cli {
 	fn impl_name() -> String {
@@ -70,51 +70,69 @@ pub fn run() -> sc_cli::Result<()> {
 		Some(Subcommand::BuildSpec(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 			runner.sync_run(|config| cmd.run(config.chain_spec, config.network))
-		},
+		}
 		Some(Subcommand::CheckBlock(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
-				let PartialComponents { client, task_manager, import_queue, ..}
-					= service::new_partial(&config)?;
+				let PartialComponents {
+					client,
+					task_manager,
+					import_queue,
+					..
+				} = service::new_partial(&config)?;
 				Ok((cmd.run(client, import_queue), task_manager))
 			})
-		},
+		}
 		Some(Subcommand::ExportBlocks(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
-				let PartialComponents { client, task_manager, ..}
-					= service::new_partial(&config)?;
+				let PartialComponents {
+					client,
+					task_manager,
+					..
+				} = service::new_partial(&config)?;
 				Ok((cmd.run(client, config.database), task_manager))
 			})
-		},
+		}
 		Some(Subcommand::ExportState(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
-				let PartialComponents { client, task_manager, ..}
-					= service::new_partial(&config)?;
+				let PartialComponents {
+					client,
+					task_manager,
+					..
+				} = service::new_partial(&config)?;
 				Ok((cmd.run(client, config.chain_spec), task_manager))
 			})
-		},
+		}
 		Some(Subcommand::ImportBlocks(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
-				let PartialComponents { client, task_manager, import_queue, ..}
-					= service::new_partial(&config)?;
+				let PartialComponents {
+					client,
+					task_manager,
+					import_queue,
+					..
+				} = service::new_partial(&config)?;
 				Ok((cmd.run(client, import_queue), task_manager))
 			})
-		},
+		}
 		Some(Subcommand::PurgeChain(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 			runner.sync_run(|config| cmd.run(config.database))
-		},
+		}
 		Some(Subcommand::Revert(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
-				let PartialComponents { client, task_manager, backend, ..}
-					= service::new_partial(&config)?;
+				let PartialComponents {
+					client,
+					task_manager,
+					backend,
+					..
+				} = service::new_partial(&config)?;
 				Ok((cmd.run(client, backend), task_manager))
 			})
-		},
+		}
 		Some(Subcommand::Benchmark(cmd)) => {
 			if cfg!(feature = "runtime-benchmarks") {
 				let runner = cli.create_runner(cmd)?;
@@ -122,16 +140,18 @@ pub fn run() -> sc_cli::Result<()> {
 				runner.sync_run(|config| cmd.run::<Block, service::Executor>(config))
 			} else {
 				Err("Benchmarking wasn't enabled when building the node. \
-				You can enable it with `--features runtime-benchmarks`.".into())
+				You can enable it with `--features runtime-benchmarks`."
+					.into())
 			}
-		},
+		}
 		None => {
 			let runner = cli.create_runner(&cli.run)?;
 			runner.run_node_until_exit(|config| async move {
 				match config.role {
 					Role::Light => service::new_light(config),
 					_ => service::new_full(config),
-				}.map_err(sc_cli::Error::Service)
+				}
+				.map_err(sc_cli::Error::Service)
 			})
 		}
 	}

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,3 +1,3 @@
 pub mod chain_spec;
-pub mod service;
 pub mod rpc;
+pub mod service;

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -8,12 +8,11 @@
 use std::sync::Arc;
 
 use anmol_runtime::{opaque::Block, AccountId, Balance, Index};
-use sp_api::ProvideRuntimeApi;
-use sp_blockchain::{Error as BlockChainError, HeaderMetadata, HeaderBackend};
-use sp_block_builder::BlockBuilder;
 pub use sc_rpc_api::DenyUnsafe;
+use sp_api::ProvideRuntimeApi;
+use sp_block_builder::BlockBuilder;
+use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 use sp_transaction_pool::TransactionPool;
-
 
 /// Full client dependencies.
 pub struct FullDeps<C, P> {
@@ -26,19 +25,18 @@ pub struct FullDeps<C, P> {
 }
 
 /// Instantiate all full RPC extensions.
-pub fn create_full<C, P>(
-	deps: FullDeps<C, P>,
-) -> jsonrpc_core::IoHandler<sc_rpc::Metadata> where
+pub fn create_full<C, P>(deps: FullDeps<C, P>) -> jsonrpc_core::IoHandler<sc_rpc::Metadata>
+where
 	C: ProvideRuntimeApi<Block>,
-	C: HeaderBackend<Block> + HeaderMetadata<Block, Error=BlockChainError> + 'static,
+	C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError> + 'static,
 	C: Send + Sync + 'static,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + 'static,
 {
-	use substrate_frame_rpc_system::{FullSystem, SystemApi};
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
+	use substrate_frame_rpc_system::{FullSystem, SystemApi};
 
 	let mut io = jsonrpc_core::IoHandler::default();
 	let FullDeps {
@@ -47,13 +45,15 @@ pub fn create_full<C, P>(
 		deny_unsafe,
 	} = deps;
 
-	io.extend_with(
-		SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe))
-	);
+	io.extend_with(SystemApi::to_delegate(FullSystem::new(
+		client.clone(),
+		pool,
+		deny_unsafe,
+	)));
 
-	io.extend_with(
-		TransactionPaymentApi::to_delegate(TransactionPayment::new(client.clone()))
-	);
+	io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(
+		client.clone(),
+	)));
 
 	// Extend this RPC with a custom API by using the following syntax.
 	// `YourRpcStruct` should have a reference to a client, which is needed

--- a/pallets/kitties/src/benchmarking.rs
+++ b/pallets/kitties/src/benchmarking.rs
@@ -2,9 +2,9 @@
 
 use super::*;
 
+use frame_benchmarking::{benchmarks, impl_benchmark_test_suite, whitelisted_caller};
 use frame_system::RawOrigin;
-use frame_benchmarking::{benchmarks, whitelisted_caller, impl_benchmark_test_suite};
-use sp_std::{vec, vec::Vec, boxed::Box};
+use sp_std::{boxed::Box, vec, vec::Vec};
 
 #[allow(unused)]
 use crate::Module as KittiesModule;

--- a/pallets/kitties/src/lib.rs
+++ b/pallets/kitties/src/lib.rs
@@ -3,7 +3,6 @@
 /// Edit this file to define custom logic or remove it if it is not needed.
 /// Learn more about FRAME and the core library of Substrate FRAME pallets:
 /// <https://substrate.dev/docs/en/knowledgebase/runtime/frame>
-
 pub use pallet::*;
 
 #[cfg(test)]
@@ -66,7 +65,7 @@ pub mod pallet {
 	// These functions materialize as "extrinsics", which are often compared to transactions.
 	// Dispatchable functions must be annotated with a weight and must return a DispatchResult.
 	#[pallet::call]
-	impl<T:Config> Pallet<T> {
+	impl<T: Config> Pallet<T> {
 		/// An example dispatchable that takes a singles value as a parameter, writes the value to
 		/// storage and emits an event. This function must be dispatched by a signed extrinsic.
 		#[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
@@ -100,7 +99,7 @@ pub mod pallet {
 					// Update the value in storage with the incremented result.
 					<Something<T>>::put(new);
 					Ok(().into())
-				},
+				}
 			}
 		}
 	}

--- a/pallets/kitties/src/mock.rs
+++ b/pallets/kitties/src/mock.rs
@@ -1,10 +1,11 @@
 use crate as pallet_kitties;
-use sp_core::H256;
 use frame_support::parameter_types;
-use sp_runtime::{
-	traits::{BlakeTwo256, IdentityLookup}, testing::Header,
-};
 use frame_system as system;
+use sp_core::H256;
+use sp_runtime::{
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup},
+};
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -57,5 +58,8 @@ impl pallet_kitties::Config for Test {
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	system::GenesisConfig::default().build_storage::<Test>().unwrap().into()
+	system::GenesisConfig::default()
+		.build_storage::<Test>()
+		.unwrap()
+		.into()
 }

--- a/pallets/kitties/src/tests.rs
+++ b/pallets/kitties/src/tests.rs
@@ -1,5 +1,5 @@
-use crate::{Error, mock::*};
-use frame_support::{assert_ok, assert_noop};
+use crate::{mock::*, Error};
+use frame_support::{assert_noop, assert_ok};
 
 #[test]
 fn it_works_for_default_value() {

--- a/pallets/nft/src/mock.rs
+++ b/pallets/nft/src/mock.rs
@@ -1,13 +1,14 @@
 use crate as pallet_nft;
-use sp_core::{H256, crypto::AccountId32};
-use frame_support::{parameter_types, debug};
-use sp_runtime::{
-	traits::{BlakeTwo256, IdentityLookup, SaturatedConversion},
-	testing::Header,
-	generic, MultiSignature,
+use frame_support::{debug, parameter_types};
+use frame_system::offchain::{
+	AppCrypto, CreateSignedTransaction, SendTransactionTypes, SigningTypes,
 };
-use frame_system::{
-	offchain::{CreateSignedTransaction, AppCrypto, SigningTypes, SendTransactionTypes},
+use sp_core::{crypto::AccountId32, H256};
+use sp_runtime::{
+	generic,
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup, SaturatedConversion},
+	MultiSignature,
 };
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;

--- a/pallets/nft/src/tests.rs
+++ b/pallets/nft/src/tests.rs
@@ -1,5 +1,5 @@
-use crate::{mock::{Event, *}};
-use frame_support::{assert_ok, assert_noop};
+use crate::mock::{Event, *};
+use frame_support::{assert_noop, assert_ok};
 
 const ALICE: AccountId = AccountId::new([1u8; 32]);
 const CLASS_ID: <Runtime as orml_nft::Config>::ClassId = 0;
@@ -7,71 +7,75 @@ const CLASS_ID: <Runtime as orml_nft::Config>::ClassId = 0;
 #[test]
 fn mint_nft_works() {
 	new_test_ext().execute_with(|| {
-        let pending_nft = crate::PendingNft {
-            account_id: ALICE,
-            class_id: CLASS_ID,
-            token_data: crate::TokenData::new(vec![0, 1, 2]),
-        };
+		let pending_nft = crate::PendingNft {
+			account_id: ALICE,
+			class_id: CLASS_ID,
+			token_data: crate::TokenData::new(vec![0, 1, 2]),
+		};
 
-        assert_noop!(
-            Nft::mint_nft(Origin::signed(ALICE), vec![0], pending_nft.clone()),
-            crate::Error::<Runtime>::TryToRemoveNftWhichDoesNotExist
-        );
+		assert_noop!(
+			Nft::mint_nft(Origin::signed(ALICE), vec![0], pending_nft.clone()),
+			crate::Error::<Runtime>::TryToRemoveNftWhichDoesNotExist
+		);
 
-        assert_ok!(Nft::nft_request(Origin::signed(ALICE), CLASS_ID, pending_nft.clone().token_data));
+		assert_ok!(Nft::nft_request(
+			Origin::signed(ALICE),
+			CLASS_ID,
+			pending_nft.clone().token_data
+		));
 
-        // TODO: DispatchError for ClassNotFound
-        // assert_noop!(
-        //     Nft::mint_nft(Origin::signed(ALICE), vec![0], pending_nft.clone()),
-        //     crate::Error::<Runtime>::NftError(orml_nft::Error::<Runtime>::ClassNotFound)
-        // );
+		// TODO: DispatchError for ClassNotFound
+		// assert_noop!(
+		//     Nft::mint_nft(Origin::signed(ALICE), vec![0], pending_nft.clone()),
+		//     crate::Error::<Runtime>::NftError(orml_nft::Error::<Runtime>::ClassNotFound)
+		// );
 
-        assert_ok!(Nft::create_nft_class(Origin::signed(ALICE), vec![1]));
+		assert_ok!(Nft::create_nft_class(Origin::signed(ALICE), vec![1]));
 
-        let event = Event::pallet_nft(
-            crate::Event::NftClassCreated(
-                ALICE,
-                CLASS_ID,
-                Default::default(),
-                vec![1],
-            )
-        );
-        assert_eq!(last_event(), event);
-        
-        assert_ok!(Nft::mint_nft(Origin::signed(ALICE), vec![2], pending_nft.clone()));
+		let event = Event::pallet_nft(crate::Event::NftClassCreated(
+			ALICE,
+			CLASS_ID,
+			Default::default(),
+			vec![1],
+		));
+		assert_eq!(last_event(), event);
 
-        let event = Event::pallet_nft(
-            crate::Event::NftMinted(
-                pending_nft,
-                vec![2],
-            )
-        );
-        assert_eq!(last_event(), event);
+		assert_ok!(Nft::mint_nft(
+			Origin::signed(ALICE),
+			vec![2],
+			pending_nft.clone()
+		));
+
+		let event = Event::pallet_nft(crate::Event::NftMinted(pending_nft, vec![2]));
+		assert_eq!(last_event(), event);
 	});
 }
 
 #[test]
 fn nft_request_works() {
 	new_test_ext().execute_with(|| {
-        assert_eq!(crate::pallet::NftPendingQueue::<Runtime>::get(), vec![]);
+		assert_eq!(crate::pallet::NftPendingQueue::<Runtime>::get(), vec![]);
 
-        let token_data = crate::TokenData::new(vec![0, 0, 1]);
+		let token_data = crate::TokenData::new(vec![0, 0, 1]);
 
-        assert_ok!(Nft::nft_request(Origin::signed(ALICE), CLASS_ID, token_data.clone()));
+		assert_ok!(Nft::nft_request(
+			Origin::signed(ALICE),
+			CLASS_ID,
+			token_data.clone()
+		));
 
-        let pending_nft = crate::PendingNft {
-            account_id: ALICE,
-            class_id: CLASS_ID,
-            token_data,
-        };
+		let pending_nft = crate::PendingNft {
+			account_id: ALICE,
+			class_id: CLASS_ID,
+			token_data,
+		};
 
-        let event = Event::pallet_nft(
-            crate::Event::NftRequest(
-                pending_nft.clone(),
-            )
-        );
-        assert_eq!(last_event(), event);
+		let event = Event::pallet_nft(crate::Event::NftRequest(pending_nft.clone()));
+		assert_eq!(last_event(), event);
 
-        assert_eq!(crate::pallet::NftPendingQueue::<Runtime>::get(), vec![pending_nft]);
-    });
+		assert_eq!(
+			crate::pallet::NftPendingQueue::<Runtime>::get(),
+			vec![pending_nft]
+		);
+	});
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,53 +1,55 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
-#![recursion_limit="256"]
+#![recursion_limit = "256"]
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-use sp_std::prelude::*;
-use sp_core::{crypto::KeyTypeId, OpaqueMetadata, Encode};
-use sp_runtime::{
-	ApplyExtrinsicResult, generic, create_runtime_str, impl_opaque_keys, MultiSignature, MultiAddress,
-	transaction_validity::{TransactionValidity, TransactionSource},
-};
-use sp_runtime::traits::{
-	BlakeTwo256, Block as BlockT, AccountIdLookup, Verify, IdentifyAccount, NumberFor, SaturatedConversion,
-};
+use pallet_grandpa::fg_primitives;
+use pallet_grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use pallet_grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
-use pallet_grandpa::fg_primitives;
-use sp_version::RuntimeVersion;
+use sp_core::{crypto::KeyTypeId, Encode, OpaqueMetadata};
+use sp_runtime::traits::{
+	AccountIdLookup, BlakeTwo256, Block as BlockT, IdentifyAccount, NumberFor, SaturatedConversion,
+	Verify,
+};
+use sp_runtime::{
+	create_runtime_str, generic, impl_opaque_keys,
+	transaction_validity::{TransactionSource, TransactionValidity},
+	ApplyExtrinsicResult, MultiAddress, MultiSignature,
+};
+use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
+use sp_version::RuntimeVersion;
 
 // A few exports that help ease life for downstream crates.
-#[cfg(any(feature = "std", test))]
-pub use sp_runtime::BuildStorage;
-pub use pallet_timestamp::Call as TimestampCall;
-pub use pallet_balances::Call as BalancesCall;
-pub use sp_runtime::{Permill, Perbill};
 pub use frame_support::{
-	construct_runtime, parameter_types, StorageValue,
+	construct_runtime, debug, parameter_types,
 	traits::{KeyOwnerProofSystem, Randomness},
 	weights::{
-		Weight, IdentityFee,
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
+		IdentityFee, Weight,
 	},
-	debug,
+	StorageValue,
 };
+pub use pallet_balances::Call as BalancesCall;
+pub use pallet_timestamp::Call as TimestampCall;
 use pallet_transaction_payment::CurrencyAdapter;
+#[cfg(any(feature = "std", test))]
+pub use sp_runtime::BuildStorage;
+pub use sp_runtime::{Perbill, Permill};
 
-use frame_system::{
-	offchain::{CreateSignedTransaction, AppCrypto, SigningTypes, SendTransactionTypes},
+use frame_system::offchain::{
+	AppCrypto, CreateSignedTransaction, SendTransactionTypes, SigningTypes,
 };
 
+pub use orml_nft;
 /// Import the kitties pallet.
 pub use pallet_kitties;
 pub use pallet_nft;
-pub use orml_nft;
 
 /// An index to a block.
 pub type BlockNumber = u32;
@@ -386,7 +388,7 @@ pub type SignedExtra = (
 	frame_system::CheckEra<Runtime>,
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
-	pallet_transaction_payment::ChargeTransactionPayment<Runtime>
+	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;


### PR DESCRIPTION
This change includes:

- Change to the readme with instructions for running the code formatter, `cargo fmt`. 
- Formatting changes to all of the code - this consists the majority of the diffs in this PR.
- Change to the PR checks to run `rustfmt` in `check` mode on the roots of parts of the project that we edit, e.g. `runtime` and the pallets.

A few things about this:
- I had previously thought that the `.rustfmt.toml` needed additional configs according to our [coding style document](https://www.notion.so/Coding-Guidelines-3213287620504a6cac84392f9f1892b7), but after review, I think that the current configurations + defaults cover this. 
- Running the formatter as a check, for CI purposes is done like `rustfmt --check {file}`