### PR TITLE
Frevert/feature/nft class in genesis

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,6 +1,6 @@
 use anmol_runtime::{
-	AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, Signature, SudoConfig,
-	SystemConfig, WASM_BINARY,
+	AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, Signature, SudoConfig, BaseNftConfig,
+	SystemConfig, WASM_BINARY
 };
 use sc_service::{ChainType, Properties};
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -141,6 +141,16 @@ fn testnet_genesis(
 	endowed_accounts: Vec<AccountId>,
 	_enable_println: bool,
 ) -> GenesisConfig {
+	// base nft class for genesis block
+	let initial_state = vec![
+		(
+			get_account_id_from_seed::<sr25519::Public>("Alice"),
+			[0].to_vec(),
+			(),
+			[].to_vec(),
+		)
+	];
+
 	GenesisConfig {
 		frame_system: Some(SystemConfig {
 			// Add Wasm runtime to storage.
@@ -168,5 +178,8 @@ fn testnet_genesis(
 			// Assign network admin rights.
 			key: root_key,
 		}),
+		base_nft: Some(BaseNftConfig {
+			tokens: initial_state
+		})
 	}
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,6 +1,6 @@
 use anmol_runtime::{
-	AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, Signature, SudoConfig, BaseNftConfig,
-	SystemConfig, WASM_BINARY
+	AccountId, AuraConfig, BalancesConfig, BaseNftConfig, GenesisConfig, GrandpaConfig, Signature,
+	SudoConfig, SystemConfig, WASM_BINARY,
 };
 use sc_service::{ChainType, Properties};
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -142,14 +142,12 @@ fn testnet_genesis(
 	_enable_println: bool,
 ) -> GenesisConfig {
 	// base nft class for genesis block
-	let initial_state = vec![
-		(
-			get_account_id_from_seed::<sr25519::Public>("Alice"),
-			[0].to_vec(),
-			(),
-			[].to_vec(),
-		)
-	];
+	let initial_state = vec![(
+		get_account_id_from_seed::<sr25519::Public>("Alice"),
+		[0].to_vec(),
+		(),
+		[].to_vec(),
+	)];
 
 	GenesisConfig {
 		frame_system: Some(SystemConfig {
@@ -179,7 +177,7 @@ fn testnet_genesis(
 			key: root_key,
 		}),
 		base_nft: Some(BaseNftConfig {
-			tokens: initial_state
-		})
+			tokens: initial_state,
+		}),
 	}
 }

--- a/pallets/base-nft/src/lib.rs
+++ b/pallets/base-nft/src/lib.rs
@@ -170,7 +170,7 @@ pub mod module {
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
-		pub tokens: Vec<GenesisTokens<T>>,
+		pub tokens: Vec<GenesisTokens<T>>
 	}
 
 	#[cfg(feature = "std")]

--- a/pallets/base-nft/src/lib.rs
+++ b/pallets/base-nft/src/lib.rs
@@ -170,7 +170,7 @@ pub mod module {
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
-		pub tokens: Vec<GenesisTokens<T>>
+		pub tokens: Vec<GenesisTokens<T>>,
 	}
 
 	#[cfg(feature = "std")]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -359,7 +359,7 @@ construct_runtime!(
 		TransactionPayment: pallet_transaction_payment::{Module, Storage},
 		Sudo: pallet_sudo::{Module, Call, Config<T>, Storage, Event<T>},
 		NftModule: pallet_nft::{Module, Call, Storage, Event<T>},
-		BaseNft: base_nft::{Module, Storage},
+		BaseNft: base_nft::{Module, Storage, Config<T>},
 	}
 );
 


### PR DESCRIPTION
This adds a class in the genesis block for the Anmol node. This ensures an NFT class is available for use in any interaction with the Anmol node.

**Changes:**
A genesis config with a `build` extension already exists in the pallet, so that limited the scope of this. 

- Adds config to the chain spec for the base NFT pallet. 